### PR TITLE
fix: enable selecting images from album for recognition

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             <button id="openCam" class="ghost">開啟相機</button>
             <!-- 沒有拍照鍵，改用自動辨識或點影片一次辨識 -->
             <label class="file">
-              <input type="file" accept="image/*" capture="environment" id="fileInput" />從相簿/相機上傳
+              <input type="file" accept="image/*" id="fileInput" />從相簿/相機上傳
             </label>
             <label class="switch"><input type="checkbox" id="autoMode"> 自動辨識</label>
             <span class="hint">iPhone 需用 <b>HTTPS</b> 或 <b>localhost</b> 才能開相機。可直接「點影片」辨識一次。</span>


### PR DESCRIPTION
## Summary
- allow choosing images from the photo album by removing the `capture` attribute from the upload input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c89b91a08333831dad2c373ef932